### PR TITLE
Changed POSTGRE_USER to POSTGRE_USERNAME

### DIFF
--- a/manual/custom-microservices/connecting-to-postgres-from-microservice.rst
+++ b/manual/custom-microservices/connecting-to-postgres-from-microservice.rst
@@ -168,7 +168,7 @@ The standard practice is to access these parameters as environment variables and
 
       conn = psycopg2.connect(
           database='hasuradb',
-          user=os.environ['POSTGRES_USER'],
+          user=os.environ['POSTGRES_USERNAME'],
           password=os.environ['POSTGRES_PASSWORD'],
           host=os.environ['POSTGRES_HOSTNAME'],
           port=os.environ['POSTGRES_PORT']


### PR DESCRIPTION
In the k8s.yaml file environment variable name is POSTGRES_USERNAME but in the python example it was POSTGRE_USER.